### PR TITLE
Fix CSP error for Krutrim Storage images in production

### DIFF
--- a/myproject/myproject/settings.py
+++ b/myproject/myproject/settings.py
@@ -217,6 +217,7 @@ CSP_IMG_SRC = (
     "https:",
     "https://mock-krutrim-storage.com",  # Mock storage for development
     "https://*.krutrimcloud.com",  # Krutrim Cloud storage domains
+    "https://*.kos.olakrutrimsvc.com",  # Krutrim Object Storage domains
 )
 CSP_FONT_SRC = (
     "'self'",


### PR DESCRIPTION
Add Krutrim Object Storage domain to CSP_IMG_SRC directive to allow presigned URLs from blr1.kos.olakrutrimsvc.com to load properly. This resolves the Content Security Policy violation preventing MRN proof images from displaying in production.

🤖 Generated with [Claude Code](https://claude.ai/code)